### PR TITLE
修复构建问题

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,3 @@
 [submodule "themes/PaperMod"]
 	path = themes/PaperMod
 	url = https://github.com/adityatelange/hugo-PaperMod.git
-[submodule "hugo-theme-terminal"]
-	path = hugo-theme-terminal
-	url = https://github.com/panr/hugo-theme-terminal

--- a/content/showcase.md
+++ b/content/showcase.md
@@ -3,6 +3,7 @@ author = "Hugo Authors & Radek"
 title = "Showcase"
 date = "2019-03-11"
 description = "Sample article showcasing basic styling and formatting for HTML elements."
+draft = true
 +++
 
 This article offers a sample of basic Markdown syntax that can be used in Hugo content files, also it shows whether basic HTML elements are decorated with CSS in a Hugo theme.


### PR DESCRIPTION
- 清理 .gitmodules 中的旧 hugo-theme-terminal 子模块引用
- 将 showcase.md 标记为草稿以避免 Terminal 主题特定 shortcode 导致的构建失败