### PR TITLE
修复 paginate 配置错误

### DIFF
--- a/hugo.toml
+++ b/hugo.toml
@@ -3,7 +3,9 @@ languageCode = "zh-cn"
 defaultContentLanguage = "zh-cn"
 title = "Craft4Fun"
 theme = "hugo-theme-stack"
-paginate = 5
+
+[pagination]
+pagerSize = 5
 
 # 主题版权声明（Stack 主题要求）
 [params.footer]


### PR DESCRIPTION
将已弃用的 paginate 改为 pagination.pagerSize 以兼容 Hugo 0.128.0+